### PR TITLE
Hide api keys and gameids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ venv/
 *.rar
 *.tar
 *.zip
+
+
+#Hide credential file
+cred.json

--- a/ProteusCustomGalaxyConverter.py
+++ b/ProteusCustomGalaxyConverter.py
@@ -1,5 +1,11 @@
 import requests
+import json
 
+gameid,apikey=(None,None)
+with open("cred.json") as f:
+    cred = json.load(f)
+    gameid = cred['gameid']
+    apikey = cred['apikey']
 
 def call_api(game_number, api_key):
     api_version = '0.1'
@@ -10,9 +16,10 @@ def call_api(game_number, api_key):
     payload = requests.post(root, params).json()['scanning_data']
     return payload
 
+#Apply Credentials
+game_id = gameid
+key = apikey
 
-game_id = 5145734443433984
-key = 'sI1qlO'
 scanning_data = call_api(game_id, key)
 converted_dict = {"stars": []}
 key_order = ["uid", "name", "x", "y", "r", "ga", "e", "i", "s", "st", "puid", "wh"]

--- a/find_star_data.py
+++ b/find_star_data.py
@@ -1,5 +1,11 @@
 import requests
+import json
 
+gameid,apikey=(None,None)
+with open("cred.json") as f:
+    cred = json.load(f)
+    gameid = cred['gameid']
+    apikey = cred['apikey']
 
 # Calls api then returns payload
 def call_api(game_number, code, api_version):
@@ -60,7 +66,7 @@ def star_stats(payload):
         print("Invalid star UID or name")
 
 
-scanning_data = call_api(5194985387065344, 'gHRUO4', '0.1')
+scanning_data = call_api(gameid, apikey, '0.1')
 needed_function = int(input("Would you like to (1), find a player's home world or (2), get a star's stats "))
 
 if needed_function == 1:

--- a/main.py
+++ b/main.py
@@ -1,9 +1,16 @@
 import checkStarCounts as csc
 from time import sleep
+import json
 
-# Info for the API call
-game_number = "5237130488709120"  # Found in URL of game
-code = "Y6E1Ae"                   # Can be generated in options menu
+gameid,apikey=(None,None)
+with open("cred.json") as f:
+    cred = json.load(f)
+    gameid = cred['gameid']
+    apikey = cred['apikey']
+    
+game_number = gameid  # Found in URL of game
+code = apikey         # Can be generated in options menu
+    
 api_version = "0.1"               #
 
 # Main loop that calls checkStarCounts to get the amount of stars on each team every tick


### PR DESCRIPTION
Instead of hard coding api keys and game ids, put them into a file like `cred.json` in this example and make sure to put `cred.json` in the `.gitignore`.

You never want to reveal your apikeys on a public repository. Classic attack vector. I look for it all the time >.>